### PR TITLE
Expose date property for finnish ident. nr as well. Bump version.

### DIFF
--- a/lib/national_identification_number/finnish.rb
+++ b/lib/national_identification_number/finnish.rb
@@ -3,6 +3,8 @@ require 'national_identification_number/base'
 module NationalIdentificationNumber
   class Finnish < Base
 
+    attr_reader :date
+
     CHECKSUMS = %w{ 0 1 2 3 4 5 6 7 8 9 A B C D E F H J K L M N P R S T U V W X Y }
 
     protected
@@ -33,8 +35,9 @@ module NationalIdentificationNumber
           else          1900
           end
 
+
           begin
-            Date.parse("#{century+year}-#{month}-#{day}")
+            @date = Date.parse("#{century+year}-#{month}-#{day}")
             @valid = true
             @number = ("#{$1}#{$2}#{$3}#{divider}#{$5}#{checksum}")
           rescue ArgumentError

--- a/resident.gemspec
+++ b/resident.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.require_paths << 'lib'
 
   s.name        = 'resident'
-  s.version     = '0.0.9'
+  s.version     = '0.0.10'
   s.summary     = 'Validate National Identification Numbers.'
   s.homepage    = "http://github.com/bukowskis/national_identification_number/"
   s.author      = 'Bukowskis'


### PR DESCRIPTION
Expose the date object representing the national identification number for Finnish as well as Swedish numbers.
