### PR TITLE
Add support for Norwegian / Danish national identifiers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.6-node-browsers
+    environment:
+      - RACK_ENV: test
+    steps:
+      - checkout
+
+      - run:
+          name: Bundle Install
+          command: bundle install --path=vendor/bundle --jobs=4 --retry=3
+
+      - run:
+          name: Run specs
+          command: bundle exec rspec  --format progress

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,39 +1,12 @@
 PATH
   remote: .
   specs:
-    resident (0.0.11)
+    resident (0.0.12)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    celluloid (0.15.2)
-      timers (~> 1.1.0)
-    coderay (1.1.0)
     diff-lcs (1.2.5)
-    ffi (1.9.3)
-    formatador (0.2.5)
-    guard (2.6.1)
-      formatador (>= 0.2.4)
-      listen (~> 2.7)
-      lumberjack (~> 1.0)
-      pry (>= 0.9.12)
-      thor (>= 0.18.1)
-    guard-rspec (4.2.10)
-      guard (~> 2.1)
-      rspec (>= 2.14, < 4.0)
-    listen (2.7.9)
-      celluloid (>= 0.15.2)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-    lumberjack (1.0.7)
-    method_source (0.8.2)
-    pry (0.10.0)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    rb-fsevent (0.9.4)
-    rb-inotify (0.9.5)
-      ffi (>= 0.5.0)
     rspec (3.0.0)
       rspec-core (~> 3.0.0)
       rspec-expectations (~> 3.0.0)
@@ -46,20 +19,15 @@ GEM
     rspec-mocks (3.0.2)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.2)
-    slop (3.5.0)
-    thor (0.19.1)
     timecop (0.7.1)
-    timers (1.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  guard-rspec
-  rb-fsevent
   resident!
   rspec
   timecop
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 Validates a National Identification Number (See http://en.wikipedia.org/wiki/National_identification_number).
 There are some 62 countries that have this type of number.
-This gem currently only supports Swedish (Personnummer) and Finnish (Henkilöasiakkaat) ones.
 
-There is a special focus on identifying these numbers robustly (i.e. you can safely validate a param[:number] directly, or cleanup your database by running every non-normalized value through this gem).
+This gem currently only supports Swedish (Personnummer), Finnish
+(Henkilöasiakkaat), Norwegian (Fødelsenummer) and Danish (CPR).
+
+There is a special focus on identifying these numbers robustly
+(i.e. you can safely validate a param[:number] directly, or cleanup
+your database by running every non-normalized value through this gem).
 
 ## Installation
 
@@ -38,7 +42,7 @@ Some marked parts of the code are inspired or taken from MIT licensed code of
 
 Other than that you got:
 
-Copyright (c) 2011-2014 Bukowskis.
+Copyright (c) 2011-2022 Bukowskis.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/national_identification_number.rb
+++ b/lib/national_identification_number.rb
@@ -1,2 +1,4 @@
 require 'national_identification_number/swedish'
 require 'national_identification_number/finnish'
+require 'national_identification_number/norwegian'
+require 'national_identification_number/danish'

--- a/lib/national_identification_number/base.rb
+++ b/lib/national_identification_number/base.rb
@@ -41,6 +41,5 @@ module NationalIdentificationNumber
     def validate
       raise 'You need to implement at least this method in subclasses.'
     end
-
   end
 end

--- a/lib/national_identification_number/danish.rb
+++ b/lib/national_identification_number/danish.rb
@@ -1,0 +1,43 @@
+require 'national_identification_number/base'
+
+module NationalIdentificationNumber
+  class Danish < Base
+    attr_reader :date
+
+    protected
+
+    def repair
+      super
+      @number.gsub!(/[^0-9]/, '')
+      if (matches = @number.match(/\A(?<birthday>[0-9]{6})(?<checksum>[0-9]{4})\z/))
+        birthday, checksum = matches.values_at(:birthday, :checksum)
+        @number = "#{birthday}-#{checksum}"
+      end
+    end
+
+    def validate
+      if (matches = @number.match(/\A(?<day>\d{2})(?<month>\d{2})(?<year>\d{2})-(?<serial>\d{3})(?<checksum>\d{1})\z/))
+        day, month, year, serial, checksum = matches.values_at(:day, :month, :year, :serial, :checksum)
+        begin
+          @date = Date.parse("#{full_year(serial, year)}-#{month}-#{day}")
+          @valid = true
+          @number = "#{day}#{month}#{year}-#{serial}#{checksum}"
+        rescue ArgumentError
+        end
+      end
+    end
+
+    private
+
+    def full_year(serial, year)
+      century(serial, year.to_i) + year.to_i
+    end
+
+    def century(serial, year)
+      first_digit = serial[0].to_i
+      return 1800 if (5..8).include?(first_digit) && year > 57
+      return 2000 if (4..9).include?(first_digit) && year < 37
+      1900
+    end
+  end
+end

--- a/lib/national_identification_number/norwegian.rb
+++ b/lib/national_identification_number/norwegian.rb
@@ -1,0 +1,60 @@
+require 'national_identification_number/base'
+
+module NationalIdentificationNumber
+  class Norwegian < Base
+    attr_reader :date
+
+    protected
+
+    def repair
+      super
+      @number.gsub!(/[^0-9]/, '')
+    end
+
+    def validate
+      if (matches = @number.match(/\A(?<day>\d{2})(?<month>\d{2})(?<year>\d{2})(?<serial>\d{3})(?<checksum>\d{2})\z/))
+        day, month, year, serial, checksum = matches.values_at(:day, :month, :year, :serial, :checksum)
+        sans_checksum = "#{day}#{month}#{year}#{serial}"
+
+        if checksum == calculate_checksum(sans_checksum)
+          begin
+            @date = Date.parse("#{full_year(serial, year)}-#{month}-#{day}")
+            @valid = true
+            @number = "#{sans_checksum}#{checksum}"
+          rescue ArgumentError
+          end
+        end
+      end
+    end
+
+    private
+
+    def full_year(serial, year)
+      century(serial) + year.to_i
+    end
+
+    def century(serial)
+      case serial.to_i
+      when 0..499 then 1900
+      else 2000 # or 1800, not possible to tell.
+      end
+    end
+
+    def calculate_checksum(number)
+      digits = number.split('').map(&:to_i)
+      w1 = [3, 7, 6, 1, 8, 9, 4, 5, 2]
+      w2 = [5, 4, 3, 2, 7, 6, 5, 4, 3, 2]
+
+      k1 = weighted_modulo_11(digits.zip(w1))
+      k2 = weighted_modulo_11([*digits, k1].zip(w2))
+      "#{k1}#{k2}"
+    end
+
+    def weighted_modulo_11(digits_and_weights)
+      result = 11 - (digits_and_weights.map do |terms|
+                       terms.reduce(:*)
+                     end.sum % 11)
+      result > 9 ? 0 : result
+    end
+  end
+end

--- a/resident.gemspec
+++ b/resident.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.require_paths << 'lib'
 
   s.name        = 'resident'
-  s.version     = '0.0.11'
+  s.version     = '0.0.12'
   s.summary     = 'Validate National Identification Numbers.'
   s.homepage    = "http://github.com/bukowskis/national_identification_number/"
   s.author      = 'Bukowskis'
@@ -17,7 +17,5 @@ Gem::Specification.new do |s|
   s.files       = Dir['{bin,lib,man,test,spec}/**/*', 'README*', 'LICENSE*', '*LICENSE'] & `git ls-files -z`.split("\0")
 
   s.add_development_dependency('rspec')
-  s.add_development_dependency('guard-rspec')
-  s.add_development_dependency('rb-fsevent')
   s.add_development_dependency('timecop')
 end

--- a/spec/national_identification_number/danish_spec.rb
+++ b/spec/national_identification_number/danish_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+require 'resident'
+
+describe NationalIdentificationNumber::Danish do
+  describe '#valid?' do
+    it 'recognizes valid numbers' do
+      expect(described_class.new('311257-1735')).to be_valid
+      expect(described_class.new('290444-0305')).to be_valid
+      expect(described_class.new('300168-0330')).to be_valid
+    end
+
+    it 'recognizes invalid numbers' do
+      expect(described_class.new('251379-4001')).not_to be_valid # invalid month
+      expect(described_class.new('300279-4001')).not_to be_valid # invalid day
+      expect(described_class.new('asdf')).not_to be_valid
+      expect(described_class.new('1234567890')).not_to be_valid
+      expect(described_class.new('0000000000000')).not_to be_valid
+      expect(described_class.new('000000-0000')).not_to be_valid
+      expect(described_class.new('')).not_to be_valid
+      expect(described_class.new(1234567890)).not_to be_valid
+      expect(described_class.new(:really_bad_input_value)).not_to be_valid
+    end
+  end
+
+  describe 'sanitize' do
+    context 'with valid numbers' do
+      it 'is the formatted number' do
+        expect(described_class.new('3112571735').sanitize).to eq '311257-1735'
+        expect(described_class.new('290444.0305').sanitize).to eq '290444-0305'
+        expect(described_class.new('30.01.68.03.30').sanitize).to eq '300168-0330'
+      end
+    end
+
+    context 'with invalid numbers' do
+      it 'is nil' do
+        expect(described_class.new('251379-4001').sanitize).to be_nil
+        expect(described_class.new('300279-4001').sanitize).to be_nil
+        expect(described_class.new('asdf').sanitize).to be_nil
+        expect(described_class.new('1234567890').sanitize).to be_nil
+        expect(described_class.new('0000000000000').sanitize).to be_nil
+        expect(described_class.new('000000-0000').sanitize).to be_nil
+        expect(described_class.new('').sanitize).to be_nil
+        expect(described_class.new(1234567890).sanitize).to be_nil
+        expect(described_class.new(:really_bad_input_value).sanitize).to be_nil
+      end
+    end
+  end
+
+  describe 'age' do
+    before do
+      Timecop.freeze Date.parse('2022-03-04')
+    end
+
+    it 'recognizes valid numbers' do
+      expect(described_class.new('110779-4101').age).to eq 42
+      expect(described_class.new('010100-1000').age).to eq 122
+      expect(described_class.new('110736-4002').age).to be_nil # Birthday in the future
+      expect(described_class.new('030320-5006').age).to eq 2
+      expect(described_class.new('110952-3113').age).to eq 69
+      expect(described_class.new('211164-2234').age).to eq 57
+    end
+
+    it 'is nil for invalid numbers' do
+      expect(described_class.new('251379-4001').age).to be_nil # invalid month
+      expect(described_class.new('300279-4001').age).to be_nil # invalid day
+      expect(described_class.new('asdf').age).to be_nil
+      expect(described_class.new('1234567890').age).to be_nil
+      expect(described_class.new('0000000000000').age).to be_nil
+      expect(described_class.new('000000-0000').age).to be_nil
+      expect(described_class.new('').age).to be_nil
+      expect(described_class.new(1234567890).age).to be_nil
+      expect(described_class.new(:really_bad_input_value).age).to be_nil
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns the number normalized regardless of wether its valid' do
+      expect(described_class.new('251.379.4001').to_s).to eq '251379-4001'
+    end
+  end
+end

--- a/spec/national_identification_number/norwegian_spec.rb
+++ b/spec/national_identification_number/norwegian_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+require 'resident'
+
+describe NationalIdentificationNumber::Norwegian do
+  describe '#valid?' do
+    it 'recognizes valid numbers' do
+      expect(described_class.new('11077941012')).to be_valid
+    end
+
+    it 'recognizes invalid numbers' do
+      expect(described_class.new('671301A172V')).not_to be_valid # valid checksum, invalid month
+      expect(described_class.new('830231A172M')).not_to be_valid # valid checksum, invalid day
+      expect(described_class.new('11077941010')).not_to be_valid
+      expect(described_class.new('670368A172X')).not_to be_valid
+      expect(described_class.new('310145--586A')).not_to be_valid
+      expect(described_class.new('asdf')).not_to be_valid
+      expect(described_class.new('1234567890')).not_to be_valid
+      expect(described_class.new('0000000000000')).not_to be_valid
+      expect(described_class.new('000000-0000')).not_to be_valid
+      expect(described_class.new('')).not_to be_valid
+      expect(described_class.new(1234567890)).not_to be_valid
+      expect(described_class.new(:really_bad_input_value)).not_to be_valid
+    end
+  end
+
+  describe 'sanitize' do
+    context 'with valid numbers' do
+      it 'is the formatted number' do
+        expect(described_class.new('11077941012').sanitize).to eq '11077941012'
+        expect(described_class.new('11.07.79.410.12').sanitize).to eq '11077941012'
+        expect(described_class.new('11 07 79 41012').sanitize).to eq '11077941012'
+      end
+    end
+
+    context 'with invalid numbers' do
+      it 'is nil' do
+        expect(described_class.new('11077941010').sanitize).to be_nil
+        expect(described_class.new('671301A172V').sanitize).to be_nil
+        expect(described_class.new('830231A172M').sanitize).to be_nil
+        expect(described_class.new('311180-999J').sanitize).to be_nil
+        expect(described_class.new('131052-308S').sanitize).to be_nil
+        expect(described_class.new('290164X862U').sanitize).to be_nil
+        expect(described_class.new('670368A172X').sanitize).to be_nil
+        expect(described_class.new('310145--586A').sanitize).to be_nil
+        expect(described_class.new('asdf').sanitize).to be_nil
+        expect(described_class.new('1234567890').sanitize).to be_nil
+        expect(described_class.new('0000000000000').sanitize).to be_nil
+        expect(described_class.new('000000-0000').sanitize).to be_nil
+        expect(described_class.new('').sanitize).to be_nil
+        expect(described_class.new(1234567890).sanitize).to be_nil
+        expect(described_class.new(:really_bad_input_value).sanitize).to be_nil
+      end
+    end
+  end
+
+  describe 'age' do
+    before do
+      Timecop.freeze Date.parse('2022-03-04')
+    end
+
+    it 'recognizes valid numbers' do
+      expect(described_class.new('11077941012').age).to eq 42
+      expect(described_class.new('01010010000').age).to eq 122
+      expect(described_class.new('11077950020').age).to be_nil # Birthday in the future
+      expect(described_class.new('03032050068').age).to eq 2
+      expect(described_class.new('11095231138').age).to eq 69
+      expect(described_class.new('21116422341').age).to eq 57
+    end
+
+    it 'is nil for invalid numbers' do
+      expect(described_class.new('671301A172V').age).to be_nil
+      expect(described_class.new('830231A172M').age).to be_nil
+      expect(described_class.new('311180-999J').age).to be_nil
+      expect(described_class.new('131052-308S').age).to be_nil
+      expect(described_class.new('290164X862U').age).to be_nil
+      expect(described_class.new('670368A172X').age).to be_nil
+      expect(described_class.new('310145--586A').age).to be_nil
+      expect(described_class.new('asdf').age).to be_nil
+      expect(described_class.new('1234567890').age).to be_nil
+      expect(described_class.new('0000000000000').age).to be_nil
+      expect(described_class.new('000000-0000').age).to be_nil
+      expect(described_class.new('').age).to be_nil
+      expect(described_class.new(1234567890).age).to be_nil
+      expect(described_class.new(:really_bad_input_value).age).to be_nil
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns the number normalized regardless of wether it is valid' do
+      expect(described_class.new('311280999J').to_s).to eq '311280999'
+      expect(described_class.new('27..036.8A172X  ').to_s).to eq '270368172'
+      expect(described_class.new('xx270368A172X  ').to_s).to eq '270368172'
+      expect(described_class.new('xxx270368A172Xt  ').to_s).to eq '270368172'
+      expect(described_class.new('\t050126-1853').to_s).to eq '0501261853'
+    end
+  end
+end


### PR DESCRIPTION
- Norwegian fødelsnummer with checksum calculation

- Danish CPR-number without any checksum calculation (as it was
  abandoned 2017 for practical reasons)

Implements #2.