### PR TITLE
Handle input of 12 digit swedish national identifiers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    resident (0.0.12)
+    resident (0.0.15)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/national_identification_number/swedish.rb
+++ b/lib/national_identification_number/swedish.rb
@@ -25,8 +25,22 @@ module NationalIdentificationNumber
 
     protected
 
+    def parse_twelve_digits
+      return unless @number.match(/\A(\d{4})(\d{2})(\d{2})(\d{4})\Z/)
+      year = $1
+      month = $2
+      day = $3
+      born = Date.new(year.to_i, month.to_i, day.to_i)
+      sep = born < Date.today.prev_year(100) ? '+' : '-'
+      @number = "#{year[2..]}#{month}#{day}#{sep}#{$4}"
+    rescue Date::Error
+      nil
+    end
+
     def repair
       super
+      return if parse_twelve_digits
+
       if @number.match(/\A(\d{0}|\d{2})(\d{6})(\-{0,1})(\d{4})\Z/)
         @number = "#{$2}-#{$4}"
       else
@@ -47,7 +61,7 @@ module NationalIdentificationNumber
            year    = $1.to_i
            month   = $2.to_i
            day     = $3.to_i
-           divider ||= $4 ||'-'
+           divider = $4 || '-'
            serial  = $5.to_i
 
            today = Date.today
@@ -59,7 +73,6 @@ module NationalIdentificationNumber
              century = 1800
            else
              preliminary_age = age_for_dob(Date.parse("#{1900 + year}-#{month}-#{day}")) rescue 0
-             #raise preliminary_age.inspect
              if preliminary_age > 99
                # It's unlikely that the person is older than 99, so assume a child when no divider was provided.
                century = 2000

--- a/resident.gemspec
+++ b/resident.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.require_paths << 'lib'
 
   s.name        = 'resident'
-  s.version     = '0.0.14'
+  s.version     = '0.0.15'
   s.summary     = 'Validate National Identification Numbers.'
   s.homepage    = "http://github.com/bukowskis/national_identification_number/"
   s.author      = 'Bukowskis'

--- a/spec/national_identification_number/swedish_spec.rb
+++ b/spec/national_identification_number/swedish_spec.rb
@@ -62,7 +62,7 @@ describe Swedish, '.generate' do
     end
 
     context 'valid numbers' do
-      it 'is the sanitize dnumber' do
+      it 'is the sanitize number' do
         expect(Swedish.new('19180123-2669').sanitize).to eq '180123-2669'
         expect(Swedish.new('00180123-2669').sanitize).to eq '180123-2669'
         expect(Swedish.new('000180123-2669').sanitize).to eq '180123-2669'
@@ -71,6 +71,11 @@ describe Swedish, '.generate' do
         expect(Swedish.new('050112-2451').sanitize).to eq '050112-2451'
         expect(Swedish.new('450202-6950').sanitize).to eq '450202-6950'
         expect(Swedish.new('19450202-6950').sanitize).to eq '450202-6950'
+      end
+
+      it 'adds - or + depending on century for twelve digit formats' do
+        expect(Swedish.new('202401275181').sanitize).to eq "240127-5181"
+        expect(Swedish.new('192401275181').sanitize).to eq "240127+5181"
       end
     end
   end
@@ -125,7 +130,7 @@ describe Swedish, '.generate' do
       expect( Swedish.new('0501261853').to_s ).to eq '050126-1853'
       expect( Swedish.new('050126-1853').to_s ).to eq '050126-1853'
       expect( Swedish.new('0asdfghj501261853').to_s).to eq '050126-1853'
-      expect( Swedish.new("190501261853").to_s ).to eq '050126-1853'
+      expect( Swedish.new("190501261853").to_s ).to eq '050126+1853'
       expect( Swedish.new("19050126-1853").to_s ).to eq '050126-1853'
       expect( Swedish.new("19050126-185d3").to_s ).to eq '050126-1853'
       expect( Swedish.new("19050126-185d3\n").to_s ).to eq '050126-1853'


### PR DESCRIPTION
Assign either - or + depending on age when in 12 digit format instead
of assuming < 100 years old.